### PR TITLE
Adjust popover edge

### DIFF
--- a/ContentView.swift
+++ b/ContentView.swift
@@ -52,7 +52,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         popover.behavior = .transient
 
         DispatchQueue.main.async {
-            self.popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
+            self.popover.show(relativeTo: button.bounds, of: button, preferredEdge: .maxY)
             DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
                 self.popover.performClose(nil)
             }


### PR DESCRIPTION
## Summary
- keep the popover from covering the menu bar icon

## Testing
- `swiftc --version`

------
https://chatgpt.com/codex/tasks/task_e_6866bb977c288329875a790bf33e1fd8